### PR TITLE
Add heavy library requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # models
+
 AI Models for Tensorus
+
+## Installation
+
+Before running the models or executing the test suite, install the required dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running Tests
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+torch
+torchvision
+transformers
+scikit-learn
+xgboost
+lightgbm
+catboost
+joblib
+numpy
+pillow

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,1 +1,8 @@
+# Tests
 
+The test suite can be executed with `pytest`. Ensure the project requirements are installed first:
+
+```bash
+pip install -r ../requirements.txt
+pytest
+```


### PR DESCRIPTION
## Summary
- document how to install dependencies
- add a README for the tests
- list heavy libraries in `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846f0159e008331bacec3fb30f1afe8