### PR TITLE
Update README with project overview and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,43 @@
-# models
+# tensorus-models
 
-AI Models for Tensorus
+This repository provides a collection of machine learning models that extend the core [Tensorus](https://github.com/tensorus/tensorus) project. The models live under the `tensorus.models` namespace and rely on utilities from the main `tensorus` repository (for example `tensorus.tensor_storage`).
 
 ## Installation
 
-Before running the models or executing the test suite, install the required dependencies:
+Install the package in editable mode while in the repository directory:
 
 ```bash
-pip install -r requirements.txt
+pip install -e .
+```
+
+When published on PyPI you will also be able to install it with:
+
+```bash
+pip install tensorus-models
+```
+
+### Example
+
+```python
+from tensorus.models import LinearRegressionModel
 ```
 
 ## Running Tests
 
+The tests require the core `tensorus` package so that `tensorus.tensor_storage` can be imported. Either clone the main repository and install it, or install it from PyPI:
+
 ```bash
+# Option 1: clone Tensorus
+git clone https://github.com/tensorus/tensorus
+pip install -e tensorus
+
+# Option 2: install from PyPI
+pip install tensorus
+```
+
+After installing `tensorus` and the requirements for this repository, run:
+
+```bash
+pip install -r requirements.txt
 pytest
 ```


### PR DESCRIPTION
## Summary
- expand README with details on Tensorus relationship
- add installation examples and usage snippet
- document how to run tests alongside the Tensorus repo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846f0b8b5c483319d08090b504dec78